### PR TITLE
Removing unused imports and variables and Pinning PTL to 1.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,5 @@ jobs:
       - name: Run tests
         run: |
           export PATH="$CONDA_BIN:$PATH"
-          pip install pytorch_lightning sklearn
+          pip install pytorch_lightning==1.0.5 sklearn
           pytest tests --color=yes --verbose

--- a/examples/IrisClassification/conda.yaml
+++ b/examples/IrisClassification/conda.yaml
@@ -10,5 +10,5 @@ dependencies:
   - sklearn
   - cloudpickle==1.6.0
   - boto3
-  - pytorch_lightning>=1.0.2
+  - pytorch_lightning==1.0.5
 

--- a/examples/Iris_TorchScript/iris_classification.py
+++ b/examples/Iris_TorchScript/iris_classification.py
@@ -1,14 +1,11 @@
 import argparse
 
-from sklearn.datasets import load_iris
-import torch.nn as nn
-from torch.utils.data import TensorDataset
+import mlflow.pytorch
 import pytorch_lightning as pl
 import torch
-import mlflow.pytorch
+import torch.nn as nn
 from sklearn.metrics import accuracy_score
 from torch.nn import functional as F
-from torch.utils.data.dataloader import DataLoader
 
 
 class IrisClassification(pl.LightningModule):

--- a/examples/Iris_TorchScript/iris_handler.py
+++ b/examples/Iris_TorchScript/iris_handler.py
@@ -37,9 +37,6 @@ class IRISClassifierHandler(BaseHandler):
         if not os.path.isfile(model_pt_path):
             raise RuntimeError("Missing the model.pt file")
 
-        # model def file
-        model_file = self.manifest["model"].get("modelFile", "")
-
         logger.debug("Loading torchscript model")
         self.model = self._load_torchscript_model(model_pt_path)
 
@@ -47,9 +44,6 @@ class IRISClassifierHandler(BaseHandler):
         self.model.eval()
 
         logger.debug("Model file %s loaded successfully", model_pt_path)
-
-        # Load class mapping for classifiers
-        mapping_file_path = os.path.join(model_dir, "index_to_name.json")
 
         self.initialized = True
 


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

Removing unused imports and variables and Pinning PTL to 1.0.5

## How is this patch tested?

Build should pass

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [ ] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
