### PR TITLE
Don't install python packages in test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,13 @@ jobs:
       - name: Check Java version
         run: |
           java -version
+      - name: Enable conda
+        run: |
+          echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |
           pip install -e .
-          pip install pytest==6.1.1 torchvision
+          pip install pytest==6.1.1 torchvision pytorch_lightning==1.0.5 scikit-learn
       - name: Run torchserve example
         run: |
           set -x
@@ -65,6 +68,4 @@ jobs:
 
       - name: Run tests
         run: |
-          export PATH="$CONDA_BIN:$PATH"
-          pip install pytorch_lightning==1.0.5 sklearn
           pytest tests --color=yes --verbose --durations=5


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Install `pytorch-lightning` and `scikit-learn ` in the `install dependencies` step to avoid generating unrelated logs (which make it difficult to debug) in the `run test` step.

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [ ] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
