### PR TITLE
Specify `long_description_content_type` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     version="0.1.0",
     description="Torch Serve Mlflow Deployment",
     long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     packages=find_packages(),
     # Require MLflow as a dependency of the plugin, so that plugin users can simply install
     # the plugin & then immediately use it with MLflow


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Specify `long_description_content_type` to redner the project description properly on PyPI.

It's not rendered properly now:

![Screen Shot 2020-11-12 at 17 10 11](https://user-images.githubusercontent.com/17039389/98912884-0644b980-250a-11eb-8f85-93e424d0a17f.png)


## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [ ] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
