### PR TITLE
[DO NOT MERGE ] Iris Example - To save as entire model and state dict and test

### DIFF
--- a/examples/IrisClassification/iris_classification.py
+++ b/examples/IrisClassification/iris_classification.py
@@ -2,8 +2,11 @@
 # pylint: disable=W0613
 # pylint: disable=W0223
 import argparse
+import os
+import shutil
 from argparse import ArgumentParser
 
+import mlflow.pytorch
 import pytorch_lightning as pl
 import torch
 import torch.nn as nn
@@ -122,4 +125,15 @@ if __name__ == "__main__":
     trainer.fit(model, dm)
     trainer.test()
 
-    torch.save(model.state_dict(), "iris.pt")
+
+    # Save model as state dict
+    if os.path.exists("model_state_dict"):
+        shutil.rmtree("model_state_dict")
+    mlflow.pytorch.save_state_dict(pytorch_model=model, path="model_state_dict")
+
+    # Save the entire model
+    if os.path.exists("entire_model"):
+        shutil.rmtree("entire_model")
+    mlflow.pytorch.save_model(pytorch_model=model, path="entire_model")
+
+

--- a/examples/IrisClassification/save_and_load_test.py
+++ b/examples/IrisClassification/save_and_load_test.py
@@ -1,0 +1,30 @@
+import json
+
+import mlflow.pytorch
+import numpy as np
+import torch
+from iris_classification import IrisClassification
+
+
+def predict(model):
+    model.eval()
+    inference_output = model(torch.tensor([4.4000, 3.0000, 1.3000, 0.2000]))
+    predicted_idx = str(np.argmax(inference_output.cpu().detach().numpy()))
+    with open("index_to_name.json") as fp:
+        data = json.load(fp)
+        return data[predicted_idx]
+
+# Save as state dict, load the model and predict
+
+
+iris = IrisClassification()
+s_model = mlflow.pytorch.load_state_dict("model_state_dict", iris)
+print("State dict prediction Result:", predict(s_model))
+
+
+# Save the entire model, load the model and predict
+
+e_model = mlflow.pytorch.load_model("entire_model")
+print("Entire model prediction Result:", predict(e_model))
+
+

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -252,14 +252,6 @@ class LightningMNISTClassifier(pl.LightningModule):
         return [optimizer], [scheduler]
 
 
-def get_model(trainer):
-    is_dp_module = isinstance(
-        trainer.model, (LightningDistributedDataParallel, LightningDataParallel)
-    )
-    model = trainer.model.module if is_dp_module else trainer.model
-    return model
-
-
 if __name__ == "__main__":
     parser = ArgumentParser(description="PyTorch Autolog Mnist Example")
 
@@ -291,7 +283,3 @@ if __name__ == "__main__":
 
     trainer.fit(model, dm)
     trainer.test()
-
-    model = get_model(trainer)
-
-    torch.save(model.state_dict(), "model.pth")

--- a/examples/MNIST/register.py
+++ b/examples/MNIST/register.py
@@ -1,0 +1,13 @@
+import sys
+import mlflow
+
+if len(sys.argv) != 3:
+    raise Exception("python register.py <model_uri> <model_name>")
+
+model_uri = sys.argv[1]
+model_name = sys.argv[2]
+
+registered_model = mlflow.register_model(model_uri, model_name)
+print("Model Registerd Successfully")
+print("Registered Name: ", registered_model.name)
+print("Registered Version: ", registered_model.version)


### PR DESCRIPTION


Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

Adding a sample script to test the state dict mlflow fix

## How is this patch tested?

Run the example and perform prediction using `save_and_load_test.py`

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [ ] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
