### PR TITLE
Adding end to end unit test examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
-          pip install pytest==6.1.1 torchvision pytorch_lightning==1.0.5 scikit-learn
+          pip install pytest==6.1.1 torchvision pytorch_lightning>=1.0.5 scikit-learn gorilla transformers torchtext matplotlib
+
       - name: Run torchserve example
         run: |
           set -x

--- a/examples/MNIST/create_deployment.py
+++ b/examples/MNIST/create_deployment.py
@@ -10,6 +10,10 @@ def create_deployment(parser_args):
         "HANDLER": parser_args["handler"],
         "EXTRA_FILES": parser_args["extra_files"],
     }
+
+    if parser_args["export_path"] != "":
+        config["EXPORT_PATH"] = parser_args["export_path"]
+
     result = plugin.create_deployment(
         name=parser_args["deployment_name"],
         model_uri=parser_args["serialized_file"],
@@ -62,6 +66,13 @@ if __name__ == "__main__":
         type=str,
         default="model.pth",
         help="Pytorch model path (default: model.pth)",
+    )
+
+    parser.add_argument(
+        "--export_path",
+        type=str,
+        default="",
+        help="Path to model store (default: '')",
     )
 
     args = parser.parse_args()

--- a/mlflow_torchserve/__init__.py
+++ b/mlflow_torchserve/__init__.py
@@ -118,7 +118,14 @@ class TorchServePlugin(BaseDeploymentClient):
             key: val
             for key, val in config.items()
             if key.upper()
-            not in ["VERSION", "MODEL_FILE", "HANDLER", "EXTRA_FILES", "REQUIREMENTS_FILE"]
+            not in [
+                "VERSION",
+                "MODEL_FILE",
+                "HANDLER",
+                "EXTRA_FILES",
+                "REQUIREMENTS_FILE",
+                "EXPORT_PATH",
+            ]
         }
 
         self.register_model(
@@ -409,10 +416,12 @@ class TorchServePlugin(BaseDeploymentClient):
         if config:
             for key in config:
                 query_path += "&" + key + "=" + str(config[key])
-        else:
+
+        if "initial_workers" not in query_path:
             query_path += "&initial_workers=" + str(1)
 
         url = "{}/{}?url={}".format(self.management_api, "models", query_path)
+
         resp = requests.post(url=url)
 
         if resp.status_code != 200:

--- a/tests/examples/test_end_to_end_example.py
+++ b/tests/examples/test_end_to_end_example.py
@@ -1,0 +1,73 @@
+import pytest
+import os
+from mlflow.utils import process
+
+
+@pytest.mark.usefixtures("start_torchserve")
+def test_mnist_example():
+    os.environ["MKL_THREADING_LAYER"] = "GNU"
+    home_dir = os.getcwd()
+    mnist_dir = "examples/MNIST"
+    example_command = ["python", "mnist_model.py", "--max_epochs", "1"]
+    process.exec_cmd(example_command, cwd=mnist_dir)
+
+    assert os.path.exists(os.path.join(mnist_dir, "model.pth"))
+    create_deployment_command = [
+        "python",
+        "create_deployment.py",
+        "--export_path",
+        os.path.join(home_dir, "model_store"),
+    ]
+
+    process.exec_cmd(create_deployment_command, cwd=mnist_dir)
+
+    assert os.path.exists(os.path.join(home_dir, "model_store", "mnist_classification.mar"))
+
+    predict_command = ["python", "predict.py"]
+    res = process.exec_cmd(predict_command, cwd=mnist_dir)
+    assert "ONE" in res[1]
+
+
+@pytest.mark.usefixtures("start_torchserve")
+def test_iris_example(tmpdir):
+    iris_dir = os.path.join("examples", "IrisClassification")
+    iris_dir_absolute_path = os.path.join(os.getcwd(), iris_dir)
+    example_command = ["python", "iris_classification.py"]
+    process.exec_cmd(example_command, cwd=iris_dir)
+    model_uri = os.path.join(iris_dir_absolute_path, "iris.pt")
+    model_file_path = os.path.join(iris_dir_absolute_path, "iris_classification.py")
+    handler_file_path = os.path.join(iris_dir_absolute_path, "iris_handler.py")
+    extra_file_path = os.path.join(iris_dir_absolute_path, "index_to_name.json")
+    input_file_path = os.path.join(iris_dir_absolute_path, "sample.json")
+    output_file_path = os.path.join(str(tmpdir), "output.json")
+    create_deployment_command = [
+        "mlflow deployments create "
+        "--name iris_test_29 "
+        "--target torchserve "
+        "--model-uri {model_uri} "
+        '-C "MODEL_FILE={model_file}" '
+        '-C "HANDLER={handler_file}" '
+        '-C "EXTRA_FILES={extra_file}"'.format(
+            model_uri=model_uri,
+            model_file=model_file_path,
+            handler_file=handler_file_path,
+            extra_file=extra_file_path,
+        ),
+    ]
+
+    process.exec_cmd(create_deployment_command, shell=True)
+
+    predict_command = [
+        "mlflow deployments predict "
+        "--name iris_test_29 "
+        "--target torchserve "
+        "--input-path {} --output-path {}".format(input_file_path, output_file_path)
+    ]
+
+    process.exec_cmd(predict_command, cwd=iris_dir, shell=True)
+    assert os.path.exists(output_file_path)
+
+    with open(output_file_path) as fp:
+        result = fp.read()
+
+    assert "SETOSA" in result


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

Adding two new unit tests to deploy model into torchserve. 

MNIST - for deployment using Plugin
Iris - for deployent using cli

## How is this patch tested?

Unit tests passed - https://github.com/chauhang/mlflow-torchserve-1/pull/2

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [x] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
