### PR TITLE
Fix bug in accuracy calculation

### DIFF
--- a/examples/BertNewsClassification/news_classifier.py
+++ b/examples/BertNewsClassification/news_classifier.py
@@ -289,7 +289,7 @@ class NewsClassifier(nn.Module):
                 correct_predictions += torch.sum(preds == targets)
                 losses.append(loss.item())
 
-        return correct_predictions.double() / len(data_loader), np.mean(losses)
+        return correct_predictions.double() / len(data_loader) / self.BATCH_SIZE, np.mean(losses)
 
     def get_predictions(self, model, data_loader):
 

--- a/examples/BertNewsClassification/news_classifier.py
+++ b/examples/BertNewsClassification/news_classifier.py
@@ -258,7 +258,7 @@ class NewsClassifier(nn.Module):
             self.optimizer.zero_grad()
 
         return (
-            correct_predictions.double() / len(self.train_data_loader),
+            correct_predictions.double() / len(self.train_data_loader) / self.BATCH_SIZE,
             np.mean(losses),
         )
 


### PR DESCRIPTION
The result of `torch.sum(preds == targets)` could be as much as `self.BATCH_SIZE`, so `len(data_loader)` isn't enough of a denominator. The accuracy that it logs to MLflow is 12-13.

There could be batches from the `data_loader` with less than `BATCH_SIZE`, so a running counter of would be more accurate, but I think this is good enough.

## What changes are proposed in this pull request?

Small fix to accuracy calculation

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [X] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
