### PR TITLE
Fixing accuracy with PTL>=1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
-          pip install pytest==6.1.1 torchvision pytorch_lightning==1.2.0 scikit-learn gorilla transformers torchtext matplotlib captum
+          pip install pytest==6.1.1 torchvision pytorch_lightning>=1.2.0 scikit-learn gorilla transformers torchtext matplotlib captum
 
       - name: Run torchserve example
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
-          pip install pytest==6.1.1 torchvision pytorch_lightning==1.1.1 scikit-learn gorilla transformers torchtext matplotlib captum
+          pip install pytest==6.1.1 torchvision pytorch_lightning==1.2.0 scikit-learn gorilla transformers torchtext matplotlib captum
 
       - name: Run torchserve example
         run: |

--- a/examples/BertNewsClassification/news_classifier.py
+++ b/examples/BertNewsClassification/news_classifier.py
@@ -137,7 +137,7 @@ class NewsClassifier(nn.Module):
         """
         Creates train, valid and test dataloaders from the csv data
         """
-        dataset_tar = download_from_url(URLS["AG_NEWS"], root=".data")
+        dataset_tar = download_from_url(URLS["AG_NEWS"], root="./data")
         extracted_files = extract_archive(dataset_tar)
 
         for fname in extracted_files:

--- a/examples/E2EBert/conda.yaml
+++ b/examples/E2EBert/conda.yaml
@@ -15,4 +15,4 @@ dependencies:
   - boto3
   - transformers
   - torchtext
-  - pytorch-lightning==1.2.0
+  - pytorch-lightning>=1.2.0

--- a/examples/E2EBert/conda.yaml
+++ b/examples/E2EBert/conda.yaml
@@ -15,4 +15,4 @@ dependencies:
   - boto3
   - transformers
   - torchtext
-  - pytorch-lightning==1.1.1
+  - pytorch-lightning==1.2.0

--- a/examples/E2EBert/news_classifier.py
+++ b/examples/E2EBert/news_classifier.py
@@ -303,7 +303,7 @@ class BertNewsClassifier(pl.LightningModule):
         attention_mask = train_batch["attention_mask"]
         targets = train_batch["targets"]
         output = self.forward(input_ids, attention_mask)
-        _,y_hat =torch.max(output,dim=1)
+        _, y_hat = torch.max(output, dim=1)
         loss = F.cross_entropy(output, targets)
         self.train_acc(y_hat, targets)
         self.log("train_acc", self.train_acc.compute().cpu())
@@ -341,7 +341,7 @@ class BertNewsClassifier(pl.LightningModule):
         attention_mask = val_batch["attention_mask"]
         targets = val_batch["targets"]
         output = self.forward(input_ids, attention_mask)
-        _,y_hat =torch.max(output,dim=1)
+        _, y_hat = torch.max(output, dim=1)
         loss = F.cross_entropy(output, targets)
         self.val_acc(y_hat, targets)
         self.log("val_acc", self.val_acc.compute().cpu())

--- a/examples/E2EBert/news_classifier.py
+++ b/examples/E2EBert/news_classifier.py
@@ -303,8 +303,9 @@ class BertNewsClassifier(pl.LightningModule):
         attention_mask = train_batch["attention_mask"]
         targets = train_batch["targets"]
         output = self.forward(input_ids, attention_mask)
+        _,y_hat =torch.max(output,dim=1)
         loss = F.cross_entropy(output, targets)
-        self.train_acc(output, targets)
+        self.train_acc(y_hat, targets)
         self.log("train_acc", self.train_acc.compute().cpu())
         self.log("train_loss", loss.cpu())
         return {"loss": loss}
@@ -340,8 +341,9 @@ class BertNewsClassifier(pl.LightningModule):
         attention_mask = val_batch["attention_mask"]
         targets = val_batch["targets"]
         output = self.forward(input_ids, attention_mask)
+        _,y_hat =torch.max(output,dim=1)
         loss = F.cross_entropy(output, targets)
-        self.val_acc(output, targets)
+        self.val_acc(y_hat, targets)
         self.log("val_acc", self.val_acc.compute().cpu())
         self.log("val_loss", loss, sync_dist=True)
 
@@ -404,7 +406,7 @@ if __name__ == "__main__":
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", verbose=True)
 
     checkpoint_callback = ModelCheckpoint(
-        filepath=os.getcwd(),
+        dirpath=os.getcwd(),
         save_top_k=1,
         verbose=True,
         monitor="val_loss",

--- a/examples/E2EBert/requirements.txt
+++ b/examples/E2EBert/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.6.0
-pytorch_lightning==1.2.0
+pytorch_lightning>=1.2.0
 torchvision
 mlflow
 gorilla

--- a/examples/E2EBert/requirements.txt
+++ b/examples/E2EBert/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.6.0
-pytorch_lightning==1.1.1
+pytorch_lightning==1.2.0
 torchvision
 mlflow
 gorilla

--- a/examples/IrisClassification/conda.yaml
+++ b/examples/IrisClassification/conda.yaml
@@ -12,5 +12,5 @@ dependencies:
   - cloudpickle==1.6.0
   - boto3
   - gorilla
-  - pytorch_lightning==1.1.1
+  - pytorch_lightning==1.2.0
 

--- a/examples/IrisClassification/conda.yaml
+++ b/examples/IrisClassification/conda.yaml
@@ -12,5 +12,5 @@ dependencies:
   - cloudpickle==1.6.0
   - boto3
   - gorilla
-  - pytorch_lightning==1.2.0
+  - pytorch_lightning>=1.2.0
 

--- a/examples/IrisClassification/iris_classification.py
+++ b/examples/IrisClassification/iris_classification.py
@@ -56,7 +56,7 @@ class IrisClassification(pl.LightningModule):
     def training_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
-        _,y_hat=torch.max(logits,dim=1)
+        _, y_hat = torch.max(logits, dim=1)
         loss = self.cross_entropy_loss(logits, y)
         self.train_acc(y_hat, y)
         self.log(
@@ -71,7 +71,7 @@ class IrisClassification(pl.LightningModule):
     def validation_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
-        _,y_hat=torch.max(logits,dim=1)
+        _, y_hat = torch.max(logits, dim=1)
         loss = F.cross_entropy(logits, y)
         self.val_acc(y_hat, y)
         self.log("val_acc", self.val_acc.compute())

--- a/examples/IrisClassification/iris_classification.py
+++ b/examples/IrisClassification/iris_classification.py
@@ -56,8 +56,9 @@ class IrisClassification(pl.LightningModule):
     def training_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
+        _,y_hat=torch.max(logits,dim=1)
         loss = self.cross_entropy_loss(logits, y)
-        self.train_acc(logits, y)
+        self.train_acc(y_hat, y)
         self.log(
             "train_acc",
             self.train_acc.compute(),
@@ -70,8 +71,9 @@ class IrisClassification(pl.LightningModule):
     def validation_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
+        _,y_hat=torch.max(logits,dim=1)
         loss = F.cross_entropy(logits, y)
-        self.val_acc(logits, y)
+        self.val_acc(y_hat, y)
         self.log("val_acc", self.val_acc.compute())
         self.log("val_loss", loss, sync_dist=True)
 

--- a/examples/IrisClassificationTorchScript/conda.yaml
+++ b/examples/IrisClassificationTorchScript/conda.yaml
@@ -14,5 +14,5 @@ dependencies:
       - boto3
       - gorilla
       - torchvision
-      - pytorch_lightning==1.1.1
+      - pytorch_lightning==1.2.0
 

--- a/examples/IrisClassificationTorchScript/conda.yaml
+++ b/examples/IrisClassificationTorchScript/conda.yaml
@@ -14,5 +14,5 @@ dependencies:
       - boto3
       - gorilla
       - torchvision
-      - pytorch_lightning==1.2.0
+      - pytorch_lightning>=1.2.0
 

--- a/examples/MNIST/conda.yaml
+++ b/examples/MNIST/conda.yaml
@@ -11,7 +11,7 @@ dependencies:
   - cloudpickle==1.6.0
   - boto3
   - matplotlib
-  - pytorch_lightning==1.1.1
+  - pytorch_lightning==1.2.0
   - pandas
   - gorilla
   - mlflow>=1.14.0

--- a/examples/MNIST/conda.yaml
+++ b/examples/MNIST/conda.yaml
@@ -11,7 +11,7 @@ dependencies:
   - cloudpickle==1.6.0
   - boto3
   - matplotlib
-  - pytorch_lightning==1.2.0
+  - pytorch_lightning>=1.2.0
   - pandas
   - gorilla
   - mlflow>=1.14.0

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -188,7 +188,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = train_batch
         logits = self.forward(x)
         loss = self.cross_entropy_loss(logits, y)
-        _,y_hat= torch.max(logits,dim=1)
+        _, y_hat = torch.max(logits, dim=1)
         self.train_acc(y_hat, y)
         self.log("train_acc", self.train_acc.compute())
         self.log("train_loss", loss)
@@ -206,7 +206,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = val_batch
         logits = self.forward(x)
         loss = self.cross_entropy_loss(logits, y)
-        _,y_hat =torch.max(logits,dim=1)
+        _, y_hat = torch.max(logits, dim=1)
         self.val_acc(y_hat, y)
         self.log("val_acc", self.val_acc.compute())
         self.log("val_loss", loss, sync_dist=True)

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -188,7 +188,8 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = train_batch
         logits = self.forward(x)
         loss = self.cross_entropy_loss(logits, y)
-        self.train_acc(logits, y)
+        _,y_hat= torch.max(logits,dim=1)
+        self.train_acc(y_hat, y)
         self.log("train_acc", self.train_acc.compute())
         self.log("train_loss", loss)
         return {"loss": loss}
@@ -205,7 +206,8 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = val_batch
         logits = self.forward(x)
         loss = self.cross_entropy_loss(logits, y)
-        self.val_acc(logits, y)
+        _,y_hat =torch.max(logits,dim=1)
+        self.val_acc(y_hat, y)
         self.log("val_acc", self.val_acc.compute())
         self.log("val_loss", loss, sync_dist=True)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
ValueError: The `preds` should be probabilities, but values were detected outside of the [0,1] range.
(Please fill in changes proposed in this fix)

## How is this patch tested?
Ran all the examples locally and All the CI test got passed
(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [x] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking change - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
