### PR TITLE
Issue - [DOC-FIX] `model_store` different between torchserve and mlflow-torchserve

### DIFF
--- a/examples/BertNewsClassification/README.md
+++ b/examples/BertNewsClassification/README.md
@@ -82,14 +82,14 @@ create an empty directory `model_store` and run the following command to start t
 
 `torchserve --start --model-store model_store`
 
+
 ## Creating a new deployment
 
 Run the following command to create a new deployment named `news_classification_test`
 
 `mlflow deployments create -t torchserve -m file:///home/ubuntu/mlflow-torchserve/examples/BertNewsClassification/models --name news_classification_test -C "MODEL_FILE=news_classifier.py" -C "HANDLER=news_classifier_handler.py"`
 
-
-Note: Torchserve plugin determines the version number by itself based on the deployment name. hence, version number
+Torchserve plugin determines the version number by itself based on the deployment name. hence, version number
 is not a mandatory argument for the plugin. For example, the above command will create a deployment `news_classification_test` with version 1.
 
 If needed, version number can also be explicitly mentioned as a config variable.
@@ -97,6 +97,11 @@ If needed, version number can also be explicitly mentioned as a config variable.
 
 `mlflow deployments create -t torchserve -m file:///home/ubuntu/mlflow-torchserve/examples/BertNewsClassification/models --name news_classification_test -C "VERSION=1.0" -C "MODEL_FILE=news_classifier.py" -C "HANDLER=news_classifier_handler.py"`
 
+Note:
+mlflow-torchserve plugin generates the mar file inside the "model_store" directory. If the `model_store` directory is not present under the current folder, 
+the plugin creates a new directory named "model_store" and generates the mar file inside it.
+
+if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with "--export-path" argument (`--export-path <path-to-model-store>`)
 
 ## Running prediction based on deployed model
 

--- a/examples/BertNewsClassification/README.md
+++ b/examples/BertNewsClassification/README.md
@@ -101,7 +101,7 @@ Note:
 mlflow-torchserve plugin generates the mar file inside the "model_store" directory. If the `model_store` directory is not present under the current folder, 
 the plugin creates a new directory named "model_store" and generates the mar file inside it.
 
-if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with "--export-path" argument (`--export-path <path-to-model-store>`)
+if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with the "EXPORT_PATH" config variable (`-C 'EXPORT_PATH=<path-to-model-store>'`)
 
 ## Running prediction based on deployed model
 

--- a/examples/E2EBert/README.md
+++ b/examples/E2EBert/README.md
@@ -101,7 +101,7 @@ Note:
 By default, the mlfow-torchserve plugin generates the mar file inside the "model_store" directory. If the model store directory is not present under the current folder, 
 the plugin creates a new directory named "model_store" and generates the mar file inside it.
 
-if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with "--export-path" argument (`--export-path <path-to-model-store>`)
+if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with the "EXPORT_PATH" config variable (`-C 'EXPORT_PATH=<path-to-model-store>'`)
 
 
 ## Running prediction based on deployed model

--- a/examples/E2EBert/README.md
+++ b/examples/E2EBert/README.md
@@ -96,6 +96,13 @@ If needed, version number can also be explicitly mentioned as a config variable.
 
 `mlflow deployments create -t torchserve -m state_dict.pth --name news_classification_test -C "VERSION=1.0" -C "MODEL_FILE=news_classifier.py" -C "HANDLER=news_classifier_handler.py" -C "EXTRA_FILES=class_mapping.json,bert_base_uncased_vocab.txt"`
 
+Note:
+
+By default, the mlfow-torchserve plugin generates the mar file inside the "model_store" directory. If the model store directory is not present under the current folder, 
+the plugin creates a new directory named "model_store" and generates the mar file inside it.
+
+if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with "--export-path" argument (`--export-path <path-to-model-store>`)
+
 
 ## Running prediction based on deployed model
 

--- a/examples/IrisClassification/README.md
+++ b/examples/IrisClassification/README.md
@@ -64,7 +64,7 @@ Note:
 mlflow-torchserve plugin generates the mar file inside the "model_store" directory. If the `model_store` directory is not present under the current folder, 
 the plugin creates a new directory named "model_store" and generates the mar file inside it.
 
-if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with "--export-path" argument (`--export-path <path-to-model-store>`)
+if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with the "EXPORT_PATH" config variable (`-C 'EXPORT_PATH=<path-to-model-store>'`)
 
 ## Running prediction based on deployed model
 

--- a/examples/IrisClassification/README.md
+++ b/examples/IrisClassification/README.md
@@ -60,6 +60,12 @@ based on the predefined mapping.
 
 `mlflow deployments  create --name iris_test --target torchserve --model-uri iris.pt -C "MODEL_FILE=iris_classification.py" -C "HANDLER=iris_handler.py" -C "EXTRA_FILES=index_to_name.json"`
 
+Note:
+mlflow-torchserve plugin generates the mar file inside the "model_store" directory. If the `model_store` directory is not present under the current folder, 
+the plugin creates a new directory named "model_store" and generates the mar file inside it.
+
+if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with "--export-path" argument (`--export-path <path-to-model-store>`)
+
 ## Running prediction based on deployed model
 
 IrisClassification model takes 4 different parameters - sepal length, sepal width, petal length and petal width.These parameters can be passed as tensor. For ex: `[4.4000, 3.0000, 1.3000, 0.2000]`.

--- a/examples/IrisClassificationTorchScript/README.md
+++ b/examples/IrisClassificationTorchScript/README.md
@@ -39,6 +39,12 @@ create an empty directory `model_store` and run the following command to start t
 
 `torchserve --start --model-store model_store`
 
+Note:
+mlflow-torchserve plugin generates the mar file inside the "model_store" directory. If the `model_store` directory is not present under the current folder, 
+the plugin creates a new directory named "model_store" and generates the mar file inside it.
+
+if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with "--export-path" argument (`--export-path <path-to-model-store>`)
+
 ## Creating a new deployment
 
 Run the following command to create a new deployment named `iris_test`

--- a/examples/IrisClassificationTorchScript/README.md
+++ b/examples/IrisClassificationTorchScript/README.md
@@ -43,7 +43,7 @@ Note:
 mlflow-torchserve plugin generates the mar file inside the "model_store" directory. If the `model_store` directory is not present under the current folder, 
 the plugin creates a new directory named "model_store" and generates the mar file inside it.
 
-if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with "--export-path" argument (`--export-path <path-to-model-store>`)
+if the torchserve is already running with a different "model_store" location, ensure to pass the "model_store" path with the "EXPORT_PATH" config variable (`-C 'EXPORT_PATH=<path-to-model-store>'`)
 
 ## Creating a new deployment
 

--- a/examples/MNIST/README.md
+++ b/examples/MNIST/README.md
@@ -55,6 +55,15 @@ For example, to create another deployment the script can be triggered as
 
 `python create_deployment.py --deployment_name mnist_deployment1`
 
+Note:
+
+if the torchserve is running with a different "model_store" locations, the model-store path 
+can be passed as input using `--export_path` argument.
+
+For example:
+
+`python create_deployment.py --deployment_name mnist_deployment1 --export_path /home/ubuntu/model_store`
+
 ## Predicting deployed model
 
 To perform prediction, run the following script

--- a/mlflow_torchserve/__init__.py
+++ b/mlflow_torchserve/__init__.py
@@ -350,6 +350,11 @@ class TorchServePlugin(BaseDeploymentClient):
         else:
             model_store = "model_store"
             if not os.path.isdir(model_store):
+                print(
+                    "model_store directory not present in the current folder. "
+                    "Creating model_store directory. To avoid this behaviour"
+                    "pass --export-path <model-store-path> as an input argument"
+                )
                 os.makedirs(model_store)
 
         cmd = (

--- a/mlflow_torchserve/__init__.py
+++ b/mlflow_torchserve/__init__.py
@@ -353,7 +353,7 @@ class TorchServePlugin(BaseDeploymentClient):
                 print(
                     "model_store directory not present in the current folder. "
                     "Creating model_store directory. To avoid this behaviour"
-                    "pass --export-path <model-store-path> as an input argument"
+                    "pass -C 'EXPORT_PATH=<model-store-path> as an input argument"
                 )
                 os.makedirs(model_store)
 


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

[DOC-FIX] `model_store` different between torchserve and mlflow-torchserve

## How is this patch tested?

Existing Unit Tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [x] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [ ] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
