### PR TITLE
Master Unit test fix

### DIFF
--- a/examples/E2EBert/news_classifier.py
+++ b/examples/E2EBert/news_classifier.py
@@ -416,5 +416,4 @@ if __name__ == "__main__":
     trainer.fit(model, dm)
     trainer.test()
     if trainer.global_rank == 0:
-        with mlflow.start_run() as run:
-            mlflow.pytorch.save_state_dict(trainer.get_model().state_dict(), ".")
+        mlflow.pytorch.save_state_dict(trainer.get_model().state_dict(), ".")

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -291,5 +291,4 @@ if __name__ == "__main__":
     model = get_model(trainer)
 
     if trainer.global_rank == 0:
-        with mlflow.start_run() as run:
-            mlflow.pytorch.save_state_dict(trainer.get_model().state_dict(), "models")
+        mlflow.pytorch.save_state_dict(trainer.get_model().state_dict(), "models")


### PR DESCRIPTION
## What changes are proposed in this pull request?

When the example is run using `mlflow run .`, the command creates an active run which is being used by `mlflow.pytorch.autolog`. 

And `mlflow.pytorch.autolog` doesn't end the run and the scope of the active run exists till end of the script (until `mlflow run .` ends). 

Due to this change in behaviour in autolog, we no longer need to start a new run for logging/saving the model at the end of the training process (since there is already an active run available).

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [ ] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
