### PR TITLE
Mlflow torchserve explain api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     # Require MLflow as a dependency of the plugin, so that plugin users can simply install
     # the plugin & then immediately use it with MLflow
     install_requires=[
-        "mlflow@git+https://github.com/chauhang/mlflow.git@master",
+        "mlflow@git+https://github.com/mlflow/mlflow.git@master",
         "torchserve",
         "torch-model-archiver",
     ],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     # Require MLflow as a dependency of the plugin, so that plugin users can simply install
     # the plugin & then immediately use it with MLflow
     install_requires=[
-        "mlflow>=1.14.0",
+        "mlflow@git+https://github.com/chauhang/mlflow.git@mlflow-cli-explain",
         "torchserve",
         "torch-model-archiver",
     ],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     # Require MLflow as a dependency of the plugin, so that plugin users can simply install
     # the plugin & then immediately use it with MLflow
     install_requires=[
-        "mlflow@git+https://github.com/chauhang/mlflow.git@mlflow-cli-explain",
+        "mlflow@git+https://github.com/chauhang/mlflow.git@master",
         "torchserve",
         "torch-model-archiver",
     ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,9 +112,8 @@ def test_create_cli_failure_without_version():
     res = runner.invoke(cli.create_deployment)
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: create [OPTIONS]\nTry 'create --help' for help.\n\n"
-           "Error: Missing option '--name'.\n"
+        and res.output == "Usage: create [OPTIONS]\nTry 'create --help' for help.\n\n"
+        "Error: Missing option '--name'.\n"
     )
     res = runner.invoke(
         cli.create_deployment,
@@ -233,9 +232,8 @@ def test_get_cli_failure(deployment_name):
     res = runner.invoke(cli.get_deployment, ["--name", deployment_name])
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: get [OPTIONS]\nTry 'get --help' for help.\n\n"
-           "Error: Missing option '--target' / '-t'.\n"
+        and res.output == "Usage: get [OPTIONS]\nTry 'get --help' for help.\n\n"
+        "Error: Missing option '--target' / '-t'.\n"
     )
 
 
@@ -256,9 +254,8 @@ def test_predict_cli_failure(deployment_name):
     )
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\n"
-           "Error: Missing option '--input-path' / '-I'.\n"
+        and res.output == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\n"
+        "Error: Missing option '--input-path' / '-I'.\n"
     )
     res = runner.invoke(
         cli.predict,
@@ -266,9 +263,8 @@ def test_predict_cli_failure(deployment_name):
     )
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\n"
-           "Error: Missing option '--target' / '-t'.\n"
+        and res.output == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\n"
+        "Error: Missing option '--target' / '-t'.\n"
     )
     res = runner.invoke(
         cli.predict,
@@ -276,9 +272,8 @@ def test_predict_cli_failure(deployment_name):
     )
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\n"
-           "Error: Missing option '--name'.\n"
+        and res.output == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\n"
+        "Error: Missing option '--name'.\n"
     )
     res = runner.invoke(
         cli.predict,
@@ -310,9 +305,8 @@ def test_explain_cli_failure(deployment_name):
     )
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\n"
-           "Error: Missing option '--input-path' / '-I'.\n"
+        and res.output == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\n"
+        "Error: Missing option '--input-path' / '-I'.\n"
     )
     res = runner.invoke(
         cli.explain,
@@ -320,9 +314,8 @@ def test_explain_cli_failure(deployment_name):
     )
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\n"
-           "Error: Missing option '--target' / '-t'.\n"
+        and res.output == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\n"
+        "Error: Missing option '--target' / '-t'.\n"
     )
     res = runner.invoke(
         cli.explain,
@@ -355,9 +348,8 @@ def test_delete_cli_failure(deployment_name):
     )
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\n"
-           "Error: Missing option '--target' / '-t'.\n"
+        and res.output == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\n"
+        "Error: Missing option '--target' / '-t'.\n"
     )
 
     res = runner.invoke(
@@ -366,9 +358,8 @@ def test_delete_cli_failure(deployment_name):
     )
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\n"
-           "Error: Missing option '--name'.\n"
+        and res.output == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\n"
+        "Error: Missing option '--name'.\n"
     )
 
     res = runner.invoke(
@@ -376,7 +367,6 @@ def test_delete_cli_failure(deployment_name):
     )
     assert (
         res.exit_code == 2
-        and res.output
-        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\n"
-           "Error: Missing option '--name'.\n"
+        and res.output == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\n"
+        "Error: Missing option '--name'.\n"
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,7 +113,8 @@ def test_create_cli_failure_without_version():
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: create [OPTIONS]\nTry 'create --help' for help.\n\nError: Missing option '--name'.\n"
+        == "Usage: create [OPTIONS]\nTry 'create --help' for help.\n\n"
+           "Error: Missing option '--name'.\n"
     )
     res = runner.invoke(
         cli.create_deployment,
@@ -233,7 +234,8 @@ def test_get_cli_failure(deployment_name):
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: get [OPTIONS]\nTry 'get --help' for help.\n\nError: Missing option '--target' / '-t'.\n"
+        == "Usage: get [OPTIONS]\nTry 'get --help' for help.\n\n"
+           "Error: Missing option '--target' / '-t'.\n"
     )
 
 
@@ -255,7 +257,8 @@ def test_predict_cli_failure(deployment_name):
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\nError: Missing option '--input-path' / '-I'.\n"
+        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\n"
+           "Error: Missing option '--input-path' / '-I'.\n"
     )
     res = runner.invoke(
         cli.predict,
@@ -264,7 +267,8 @@ def test_predict_cli_failure(deployment_name):
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\nError: Missing option '--target' / '-t'.\n"
+        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\n"
+           "Error: Missing option '--target' / '-t'.\n"
     )
     res = runner.invoke(
         cli.predict,
@@ -273,7 +277,8 @@ def test_predict_cli_failure(deployment_name):
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\nError: Missing option '--name'.\n"
+        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\n"
+           "Error: Missing option '--name'.\n"
     )
     res = runner.invoke(
         cli.predict,
@@ -306,7 +311,8 @@ def test_explain_cli_failure(deployment_name):
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\nError: Missing option '--input-path' / '-I'.\n"
+        == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\n"
+           "Error: Missing option '--input-path' / '-I'.\n"
     )
     res = runner.invoke(
         cli.explain,
@@ -315,7 +321,8 @@ def test_explain_cli_failure(deployment_name):
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\nError: Missing option '--target' / '-t'.\n"
+        == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\n"
+           "Error: Missing option '--target' / '-t'.\n"
     )
     res = runner.invoke(
         cli.explain,
@@ -349,7 +356,8 @@ def test_delete_cli_failure(deployment_name):
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\nError: Missing option '--target' / '-t'.\n"
+        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\n"
+           "Error: Missing option '--target' / '-t'.\n"
     )
 
     res = runner.invoke(
@@ -359,7 +367,8 @@ def test_delete_cli_failure(deployment_name):
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\nError: Missing option '--name'.\n"
+        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\n"
+           "Error: Missing option '--name'.\n"
     )
 
     res = runner.invoke(
@@ -368,5 +377,6 @@ def test_delete_cli_failure(deployment_name):
     assert (
         res.exit_code == 2
         and res.output
-        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\nError: Missing option '--name'.\n"
+        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\n"
+           "Error: Missing option '--name'.\n"
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,17 +15,22 @@ f_model_uri = os.path.join("tests/resources", "linear_state_dict.pt")
 
 model_version = "1.0"
 model_file_path = os.path.join("tests/resources", "linear_model.py")
+incorrect_model_file_path = os.path.join("tests/resources", "linear_model1.py")
 handler_file_path = os.path.join("tests/resources", "linear_handler.py")
 sample_input_file = os.path.join("tests/resources", "sample.json")
+sample_incorrect_input_file = os.path.join("tests/resources", "sample.txt")
+handler_file = "HANDLER={handler_file_path}".format(handler_file_path=handler_file_path)
+model_file = "MODEL_FILE={model_file_path}".format(model_file_path=model_file_path)
+incorrect_model_file = "MODEL_FILE={model_file_path}".format(
+    model_file_path=incorrect_model_file_path
+)
+runner = CliRunner()
 
 
 @pytest.mark.usefixtures("start_torchserve")
 def test_create_cli_version_success():
     version = "VERSION={version}".format(version="1.0")
-    model_file = "MODEL_FILE={model_file_path}".format(model_file_path=model_file_path)
-    handler_file = "HANDLER={handler_file_path}".format(handler_file_path=handler_file_path)
     _ = deployments.get_deploy_client(f_target)
-    runner = CliRunner()
     res = runner.invoke(
         cli.create_deployment,
         [
@@ -49,10 +54,7 @@ def test_create_cli_version_success():
 
 
 def test_create_cli_success_without_version():
-    model_file = "MODEL_FILE={model_file_path}".format(model_file_path=model_file_path)
-    handler_file = "HANDLER={handler_file_path}".format(handler_file_path=handler_file_path)
     _ = deployments.get_deploy_client(f_target)
-    runner = CliRunner()
     res = runner.invoke(
         cli.create_deployment,
         [
@@ -73,12 +75,109 @@ def test_create_cli_success_without_version():
     assert "{} deployment {} is created".format(f_flavor, f_deployment_name_version) in res.stdout
 
 
+def test_create_cli_failure_without_version():
+    _ = deployments.get_deploy_client(f_target)
+    res = runner.invoke(
+        cli.create_deployment,
+        [
+            "-f",
+            f_flavor,
+            "-m",
+            f_model_uri,
+            "-t",
+            f_target,
+            "--name",
+            f_deployment_id,
+            "-C",
+            incorrect_model_file,
+            "-C",
+            handler_file,
+        ],
+    )
+    assert str(res.exception) == "Unable to create mar file" and res.exit_code == 1
+    res = runner.invoke(
+        cli.create_deployment,
+        [
+            "-m",
+            f_model_uri,
+            "-t",
+            f_target,
+            "--name",
+            f_deployment_id,
+            "-C",
+            model_file,
+        ],
+    )
+    assert str(res.exception) == "Config Variable HANDLER - missing"
+    res = runner.invoke(cli.create_deployment)
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: create [OPTIONS]\nTry 'create --help' for help.\n\nError: Missing option '--name'.\n"
+    )
+    res = runner.invoke(
+        cli.create_deployment,
+        [
+            "-m",
+            f_model_uri,
+            "-t",
+            f_target,
+            "--name",
+            f_deployment_id,
+            "-C",
+            handler_file,
+        ],
+    )
+    assert str(res.exception) == "Unable to register the model"
+    res = runner.invoke(
+        cli.create_deployment,
+        [
+            "-t",
+            f_target,
+            "--name",
+            f_deployment_id,
+            "-C",
+            handler_file,
+            "-C",
+            model_file,
+        ],
+    )
+    assert res.exit_code == 2
+    res = runner.invoke(
+        cli.create_deployment,
+        [
+            "-m",
+            f_model_uri,
+            "--name",
+            f_deployment_id,
+            "-C",
+            handler_file,
+            "-C",
+            model_file,
+        ],
+    )
+    assert res.exit_code == 2
+    res = runner.invoke(
+        cli.create_deployment,
+        [
+            "-m",
+            f_model_uri,
+            "-t",
+            f_target,
+            "-C",
+            handler_file,
+            "-C",
+            handler_file,
+        ],
+    )
+    assert res.exit_code == 2
+
+
 @pytest.mark.parametrize(
     "deployment_name, config",
     [(f_deployment_name_version, "SET-DEFAULT=true"), (f_deployment_id, "MIN_WORKER=3")],
 )
 def test_update_cli_success(deployment_name, config):
-    runner = CliRunner()
     res = runner.invoke(
         cli.update_deployment,
         [
@@ -100,7 +199,6 @@ def test_update_cli_success(deployment_name, config):
 
 
 def test_list_cli_success():
-    runner = CliRunner()
     res = runner.invoke(cli.list_deployment, ["--target", f_target])
     assert "{}".format(f_deployment_id) in res.stdout
 
@@ -109,7 +207,6 @@ def test_list_cli_success():
     "deployment_name", [f_deployment_id, f_deployment_name_version, f_deployment_name_all]
 )
 def test_get_cli_success(deployment_name):
-    runner = CliRunner()
     res = runner.invoke(cli.get_deployment, ["--name", deployment_name, "--target", f_target])
     ret = json.loads(res.stdout.split("deploy:")[1])
     if deployment_name == f_deployment_id:
@@ -120,21 +217,156 @@ def test_get_cli_success(deployment_name):
         assert len(ret) == 2
 
 
+@pytest.mark.parametrize(
+    "deployment_name", [f_deployment_id, f_deployment_name_version, f_deployment_name_all]
+)
+def test_get_cli_failure(deployment_name):
+    res = runner.invoke(
+        cli.get_deployment,
+    )
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: get [OPTIONS]\nTry 'get --help' for help.\n\nError: Missing option '--name'.\n"
+    )
+    res = runner.invoke(cli.get_deployment, ["--name", deployment_name])
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: get [OPTIONS]\nTry 'get --help' for help.\n\nError: Missing option '--target' / '-t'.\n"
+    )
+
+
 @pytest.mark.parametrize("deployment_name", [f_deployment_name_version, f_deployment_id])
 def test_predict_cli_success(deployment_name):
-    runner = CliRunner()
     res = runner.invoke(
         cli.predict,
         ["--name", deployment_name, "--target", f_target, "--input-path", sample_input_file],
     )
-    assert res.stdout != ""
+    assert res.exit_code == 0
+
+
+@pytest.mark.parametrize("deployment_name", [f_deployment_name_version, f_deployment_id])
+def test_predict_cli_failure(deployment_name):
+    res = runner.invoke(
+        cli.predict,
+        ["--name", deployment_name, "--target", f_target],
+    )
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\nError: Missing option '--input-path' / '-I'.\n"
+    )
+    res = runner.invoke(
+        cli.predict,
+        ["--name", deployment_name, "--input-path", sample_input_file],
+    )
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\nError: Missing option '--target' / '-t'.\n"
+    )
+    res = runner.invoke(
+        cli.predict,
+        ["--target", f_target, "--input-path", sample_input_file],
+    )
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: predict [OPTIONS]\nTry 'predict --help' for help.\n\nError: Missing option '--name'.\n"
+    )
+    res = runner.invoke(
+        cli.predict,
+        [
+            "--name",
+            deployment_name,
+            "--target",
+            f_target,
+            "--input-path",
+            sample_incorrect_input_file,
+        ],
+    )
+    assert res.exception
+
+
+@pytest.mark.parametrize("deployment_name", [f_deployment_name_version, f_deployment_id])
+def test_explain_cli_success(deployment_name):
+    runner.invoke(
+        cli.explain,
+        ["--name", deployment_name, "--target", f_target, "--input-path", sample_input_file],
+    )
+
+
+@pytest.mark.parametrize("deployment_name", [f_deployment_name_version, f_deployment_id])
+def test_explain_cli_failure(deployment_name):
+    res = runner.invoke(
+        cli.explain,
+        ["--name", deployment_name, "--target", f_target],
+    )
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\nError: Missing option '--input-path' / '-I'.\n"
+    )
+    res = runner.invoke(
+        cli.explain,
+        ["--name", deployment_name, "--input-path", sample_input_file],
+    )
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: explain [OPTIONS]\nTry 'explain --help' for help.\n\nError: Missing option '--target' / '-t'.\n"
+    )
+    res = runner.invoke(
+        cli.explain,
+        [
+            "--name",
+            deployment_name,
+            "--target",
+            f_target,
+            "--input-path",
+            sample_incorrect_input_file,
+        ],
+    )
+    assert res.exception
 
 
 @pytest.mark.parametrize("deployment_name", [f_deployment_id + "/1.0", f_deployment_name_version])
 def test_delete_cli_success(deployment_name):
-    runner = CliRunner()
     res = runner.invoke(
         cli.delete_deployment,
         ["--name", deployment_name, "--target", f_target],
     )
     assert "Deployment {} is deleted".format(deployment_name) in res.stdout
+
+
+@pytest.mark.parametrize("deployment_name", [f_deployment_id + "/1.0", f_deployment_name_version])
+def test_delete_cli_failure(deployment_name):
+    res = runner.invoke(
+        cli.delete_deployment,
+        ["--name", deployment_name],
+    )
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\nError: Missing option '--target' / '-t'.\n"
+    )
+
+    res = runner.invoke(
+        cli.delete_deployment,
+        ["--target", f_target],
+    )
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\nError: Missing option '--name'.\n"
+    )
+
+    res = runner.invoke(
+        cli.delete_deployment,
+    )
+    assert (
+        res.exit_code == 2
+        and res.output
+        == "Usage: delete [OPTIONS]\nTry 'delete --help' for help.\n\nError: Missing option '--name'.\n"
+    )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -194,6 +194,20 @@ def test_predict_exception():
         client.predict(f_dummy, "sample")
 
 
+def test_explain_exception():
+    client = deployments.get_deploy_client(f_target)
+    with pytest.raises(Exception, match="Unable to parse input json string"):
+        client.explain(f_dummy, "sample")
+
+
+def test_explain_name_exception():
+    with open(sample_input_file) as fp:
+        data = fp.read()
+    client = deployments.get_deploy_client(f_target)
+    with pytest.raises(Exception, match="Unable to infer the results for the name %s" % f_dummy):
+        client.explain(f_dummy, data)
+
+
 def test_predict_name_exception():
     with open(sample_input_file) as fp:
         data = fp.read()


### PR DESCRIPTION
This PR is dependent on https://github.com/mlflow/mlflow/pull/4359

## What changes are proposed in this pull request?

https://pytorch.org/serve/inference_api.html#explanations-api

Adding support for torchserve explain API in mlflow-torchserve.

## How is this patch tested?

Added necessary unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [ ] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
