### PR TITLE
Updated the titanic example readme with mlflow commands

### DIFF
--- a/examples/Titanic/README.md
+++ b/examples/Titanic/README.md
@@ -1,8 +1,17 @@
 #Titanic features attribution analysis using Captum and TorchServe.
 
-In this example, we show how to use a pre-trained custom Titanic model to performing real time classification prediction(survived/Not survived) and features attributions with Captum and TorchServe. You can download the dataset from [here][https://biostat.app.vumc.org/wiki/pub/Main/DataSets/titanic3.csv] 
+In this example, we will demonstrate the basic features of the [Captum](https://captum.ai/) interpretability,and serving the model on torchserve through an example model trained on the Titanic survival data. you can download the data from [titanic](https://biostat.app.vumc.org/wiki/pub/Main/DataSets/titanic3.csv)
 
-The inference service would return the prediction and attribution score of features for a given test record.
+We will first train a deep neural network on the data using PyTorch and use Captum to understand which of the features were most important and how the network reached its prediction.
+
+you can get more details about used attributions methods used in this example
+
+1. [Titanic_Basic_Interpret](https://captum.ai/tutorials/Titanic_Basic_Interpret)
+2. [integrated-gradients](https://captum.ai/docs/algorithms#primary-attribution)
+3. [layer-attributions](https://captum.ai/docs/algorithms#layer-attribution)
+ 
+
+The inference service would return the prediction and  avg attribution socre of features for a given target for a input test record.
 
 ### Running the code
 

--- a/examples/Titanic/titanic_captum_interpret.py
+++ b/examples/Titanic/titanic_captum_interpret.py
@@ -17,6 +17,7 @@ import os
 from argparse import ArgumentParser
 import torch.nn as nn
 from titanic import TitanicSimpleNNModel
+import json
 
 
 def get_titanic():
@@ -355,3 +356,8 @@ if __name__ == "__main__":
         neuron_conductance(test_input_tensor)
         mlflow.log_param("Train Size", len(train_labels))
         mlflow.log_param("Test Size", len(test_labels))
+        dict = {
+            "input_file_path": [os.getcwd() + "/test_data/titanic_not_survived.csv"]
+        }  # Updating JSON file with absolute path of input csv file
+        with open(os.getcwd() + "/test_data/input.json", "w+") as out:
+            json.dump(dict, out)

--- a/examples/Titanic/titanic_handler.py
+++ b/examples/Titanic/titanic_handler.py
@@ -77,7 +77,9 @@ class TitanicHandler(BaseHandler):
         Returns:
             list : The preprocess function returns a list of Tensor and feature names
         """
-        self.input_file_path = data[0]["body"]["input_file_path"][0]
+        self.input_file_path = data[0]["input_file_path"]
+        if isinstance(self.input_file_path, bytearray):
+            self.input_file_path = self.input_file_path.decode()
         data = pd.read_csv(self.input_file_path)
         self.feature_names = list(data.columns)
         data = data.to_numpy()


### PR DESCRIPTION
Signed-off-by: Kasirajan Alayappan <kasirajan.alayappan@ideas2it.com>

This PR is dependent on https://github.com/mlflow/mlflow-torchserve/pull/70

## What changes are proposed in this pull request?

Updated the titanic example readme with mlflow deployment commands instead of curl commands.

## How is this patch tested?

Existing unittests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [x] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
