### PR TITLE
Distributed training - Model saving

### DIFF
--- a/examples/IrisClassification/iris_classification.py
+++ b/examples/IrisClassification/iris_classification.py
@@ -124,4 +124,6 @@ if __name__ == "__main__":
     trainer.fit(model, dm)
     trainer.test()
 
-    torch.save(model.state_dict(), "iris.pt")
+    state_dict = model.state_dict()
+    if trainer.global_rank == 0:
+        torch.save(state_dict, "iris.pt")

--- a/examples/IrisClassificationTorchScript/iris_classification.py
+++ b/examples/IrisClassificationTorchScript/iris_classification.py
@@ -109,5 +109,6 @@ if __name__ == "__main__":
     trainer.fit(model, dm)
     testloader = dm.setup("test")
     trainer.test(datamodule=testloader)
-    scripted_model = torch.jit.script(model)
-    torch.jit.save(scripted_model, "iris_ts.pt")
+    if trainer.global_rank == 0:
+        scripted_model = torch.jit.script(model)
+        torch.jit.save(scripted_model, "iris_ts.pt")


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

Adding rank zero fix for saving the model - distributed training

## How is this patch tested?

[iris_classification_ts_rank_zero_fix.txt](https://github.com/mlflow/mlflow-torchserve/files/6765864/iris_classification_ts_rank_zero_fix.txt)
[iris_classification_rank_zero_fix.txt](https://github.com/mlflow/mlflow-torchserve/files/6765867/iris_classification_rank_zero_fix.txt)

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [x] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
