### PR TITLE
Mar generation failure - Add stacktrace to Exception string

### DIFF
--- a/mlflow_torchserve/__init__.py
+++ b/mlflow_torchserve/__init__.py
@@ -459,7 +459,7 @@ class TorchServePlugin(BaseDeploymentClient):
         resp = requests.post(url=url)
 
         if resp.status_code != 200:
-            raise Exception("Unable to register the model")
+            raise Exception("Unable to register the model - {}", resp.text)
         return True
 
     def __get_max_version(self, name):

--- a/mlflow_torchserve/__init__.py
+++ b/mlflow_torchserve/__init__.py
@@ -422,13 +422,14 @@ class TorchServePlugin(BaseDeploymentClient):
         elif req_file_path:
             cmd = "{cmd} -r {path}".format(cmd=cmd, path=req_file_path)
 
-        return_code = subprocess.Popen(cmd, shell=True).wait()
-        if return_code != 0:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        _, error = p.communicate()
+        if p.returncode != 0:
             _logger.error(
                 "Error when attempting to load and parse JSON cluster spec from file %s",
                 cmd,
             )
-            raise Exception("Unable to create mar file")
+            raise Exception(error.decode("utf-8"))
 
         if export_path:
             mar_file = "{}/{}.mar".format(export_path, model_name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,7 +94,7 @@ def test_create_cli_failure_without_version():
             handler_file,
         ],
     )
-    assert str(res.exception) == "Unable to create mar file" and res.exit_code == 1
+    assert "No such file or directory" in str(res.exception) and res.exit_code == 1
     res = runner.invoke(
         cli.create_deployment,
         [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,7 +128,7 @@ def test_create_cli_failure_without_version():
             handler_file,
         ],
     )
-    assert str(res.exception) == "Unable to register the model"
+    assert "Unable to register the model" in str(res.exception)
     res = runner.invoke(
         cli.create_deployment,
         [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -136,7 +136,7 @@ def test_create_no_handler_exception():
 
 def test_create_wrong_handler_exception():
     client = deployments.get_deploy_client(f_target)
-    with pytest.raises(Exception, match="Unable to create mar file"):
+    with pytest.raises(Exception, match="No such file or directory"):
         client.create_deployment(
             f_deployment_id,
             f_model_uri,
@@ -147,7 +147,7 @@ def test_create_wrong_handler_exception():
 
 def test_create_wrong_model_exception():
     client = deployments.get_deploy_client(f_target)
-    with pytest.raises(Exception, match="Unable to create mar file"):
+    with pytest.raises(Exception, match="No such file or directory"):
         client.create_deployment(
             f_deployment_id,
             f_model_uri,


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

The current version of the plugin  throws a generic exceptions message during the archiver process.

Example - https://github.com/mlflow/mlflow-torchserve/issues/72 .

This PR fixes it by raising  the same error message from torch-model-archiver

For example:

```
ubuntu@ubuntu-ThinkPad-L490:~/Documents/facebook/phase2/chauhang/mlflow-torchserve-1/examples/IrisClassificationTorchScript$ mlflow deployments  create --name iris_test --target torchserve --model-uri iris_ts.pt -C "HANDLER=iris_handler1.py"  -C "EXTRA_FILES=index_to_name.json"
/home/ubuntu/anaconda3/lib/python3.8/site-packages/mlflow/tracking/_model_registry/utils.py:148: UserWarning: Failure attempting to register store for scheme "file-plugin": No module named 'mlflow_test_plugin.sqlalchemy_store'
  _model_registry_store_registry.register_entrypoints()
2021-08-18 22:32:18,773 [INFO ] epollEventLoopGroup-3-7 ACCESS_LOG - /127.0.0.1:56820 "GET /models/iris_test/all HTTP/1.1" 200 1
2021-08-18 22:32:18,773 [INFO ] epollEventLoopGroup-3-7 TS_METRICS - Requests2XX.Count:1|#Level:Host|#hostname:ubuntu-ThinkPad-L490,timestamp:null
Error when attempting to load and parse JSON cluster spec from file torch-model-archiver --force --model-name iris_test --version 3.0 --serialized-file iris_ts.pt --handler iris_handler1.py --export-path model_store --extra-files 'index_to_name.json'
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/bin/mlflow", line 8, in <module>
    sys.exit(cli())
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/mlflow/deployments/cli.py", line 132, in create_deployment
    deployment = client.create_deployment(name, model_uri, flavor, config=config_dict)
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/mlflow_torchserve/__init__.py", line 100, in create_deployment
    mar_file_path = self.__generate_mar_file(
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/mlflow_torchserve/__init__.py", line 432, in __generate_mar_file
    raise Exception(error.decode("utf-8"))
Exception: WARNING - Overwriting model_store/iris_test.mar ...
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/bin/torch-model-archiver", line 33, in <module>
    sys.exit(load_entry_point('torch-model-archiver==0.4.1', 'console_scripts', 'torch-model-archiver')())
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/model_archiver/model_packaging.py", line 55, in generate_model_archive
    package_model(args, manifest=manifest)
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/model_archiver/model_packaging.py", line 35, in package_model
    model_path = ModelExportUtils.copy_artifacts(model_name, **artifact_files)
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/model_archiver/model_packaging_utils.py", line 163, in copy_artifacts
    shutil.copy(path, model_path)
  File "/home/ubuntu/anaconda3/lib/python3.8/shutil.py", line 415, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/home/ubuntu/anaconda3/lib/python3.8/shutil.py", line 261, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
FileNotFoundError: [Errno 2] No such file or directory: 'iris_handler1.py'

```

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [x] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
