### PR TITLE
[WIP] Remote torchserve deployment - Mnist examples

### DIFF
--- a/examples/MNIST/README.md
+++ b/examples/MNIST/README.md
@@ -23,7 +23,7 @@ At the end of the training, MNIST model will be saved as state dict in the curre
 
 To deploy the model in remote torchserve instance follow
 
-the steps in `remote-deployment.rst` under `docs` folder.
+the steps in [remote-deployment.rst](../../docs/remote-deployment.rst) under `docs` folder.
 
 
 ## Deploying in local torchserve instance

--- a/examples/MNIST/create_deployment.py
+++ b/examples/MNIST/create_deployment.py
@@ -16,7 +16,7 @@ def create_deployment(parser_args):
 
     result = plugin.create_deployment(
         name=parser_args["deployment_name"],
-        model_uri=parser_args["serialized_file_path"],
+        model_uri=parser_args["registered_model_uri"],
         config=config,
     )
 
@@ -62,10 +62,10 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--serialized_file_path",
+        "--registered_model_uri",
         type=str,
-        default="models",
-        help="Pytorch model path (default: models)",
+        default="models:/mnist_classifier/3",
+        help="Registered model name (default: models:/mnist_classifier/1)",
     )
 
     parser.add_argument(

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -267,6 +267,9 @@ def get_model(trainer):
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="PyTorch Autolog Mnist Example")
+    parser.add_argument(
+        "--registration_name", type=str, default="mnist_classifier", help="Model registration name"
+    )
     parser = pl.Trainer.add_argparse_args(parent_parser=parser)
     parser = LightningMNISTClassifier.add_model_specific_args(parent_parser=parser)
     parser = MNISTDataModule.add_model_specific_args(parent_parser=parser)
@@ -291,7 +294,5 @@ if __name__ == "__main__":
     trainer.fit(model, dm)
     trainer.test()
 
-    model = get_model(trainer)
-
-    if trainer.global_rank == 0:
-        mlflow.pytorch.save_state_dict(trainer.lightning_module.state_dict(), "models")
+    run = mlflow.active_run()
+    mlflow.register_model(model_uri=run.info.artifact_uri, name=dict_args["registration_name"])


### PR DESCRIPTION
## What changes are proposed in this pull request?

The current verison of MNIST example saves the model as state_dict using `mlflow.pytorch.save_state_dict`. Since, the `mlflow.pytorch.save_state_dict` does not contain MLModel file, it is not possible to register the model into MLflow.

Updating the example with model registration.

## How is this patch tested?

Local and remote torchserve deployment

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [ ] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
