### PR TITLE
PTL 1.5.0 support

### DIFF
--- a/examples/E2EBert/news_classifier.py
+++ b/examples/E2EBert/news_classifier.py
@@ -16,7 +16,7 @@ from pytorch_lightning.callbacks import (
     ModelCheckpoint,
     LearningRateMonitor,
 )
-from pytorch_lightning.metrics import Accuracy
+from torchmetrics import Accuracy
 from sklearn.model_selection import train_test_split
 from torch import nn
 from torch.utils.data import Dataset, DataLoader

--- a/examples/E2EBert/news_classifier.py
+++ b/examples/E2EBert/news_classifier.py
@@ -450,6 +450,6 @@ if __name__ == "__main__":
         args, callbacks=[lr_logger, early_stopping, checkpoint_callback], checkpoint_callback=True
     )
     trainer.fit(model, dm)
-    trainer.test()
+    trainer.test(datamodule=dm)
     if trainer.global_rank == 0:
         torch.save(model.state_dict(), "state_dict.pth")

--- a/examples/IrisClassification/iris_classification.py
+++ b/examples/IrisClassification/iris_classification.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
     model = IrisClassification(**dict_args)
     trainer = pl.Trainer.from_argparse_args(args)
     trainer.fit(model, dm)
-    trainer.test()
+    trainer.test(datamodule=dm)
 
     input_schema = Schema(
         [

--- a/examples/IrisClassification/iris_classification.py
+++ b/examples/IrisClassification/iris_classification.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 from mlflow.models.signature import ModelSignature
 from mlflow.types.schema import Schema, ColSpec
 from pytorch_lightning import seed_everything
-from pytorch_lightning.metrics import Accuracy
+from torchmetrics import Accuracy
 from sklearn.datasets import load_iris
 from torch.utils.data import DataLoader, random_split, TensorDataset
 

--- a/examples/IrisClassificationTorchScript/iris_classification.py
+++ b/examples/IrisClassificationTorchScript/iris_classification.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     dm.setup("fit")
     trainer.fit(model, dm)
     testloader = dm.setup("test")
-    trainer.test(datamodule=testloader)
+    trainer.test(datamodule=dm)
     if trainer.global_rank == 0:
         scripted_model = torch.jit.script(model)
         torch.jit.save(scripted_model, "iris_ts.pt")

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -23,7 +23,7 @@ from torch.nn.parallel import (
     DataParallel,
 )
 from pytorch_lightning import seed_everything
-from pytorch_lightning.metrics import Accuracy
+from torchmetrics import Accuracy
 from torch.nn import functional as F
 from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, transforms

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -295,7 +295,7 @@ if __name__ == "__main__":
     trainer = pl.Trainer.from_argparse_args(args)
 
     trainer.fit(model, dm)
-    trainer.test()
+    trainer.test(datamodule=dm)
 
     run = mlflow.active_run()
     if dict_args["register"] == "true":

--- a/examples/cifar10/cifar10_train.py
+++ b/examples/cifar10/cifar10_train.py
@@ -6,7 +6,7 @@ import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
 from argparse import ArgumentParser
-from pytorch_lightning.metrics import Accuracy
+from torchmetrics import Accuracy
 from torch import nn
 from torchvision import models
 

--- a/examples/cifar10/cifar10_train.py
+++ b/examples/cifar10/cifar10_train.py
@@ -224,6 +224,6 @@ if __name__ == "__main__":
     trainer = pl.Trainer.from_argparse_args(args)
 
     trainer.fit(model, dm)
-    trainer.test()
+    trainer.test(datamodule=dm)
 
     torch.save(trainer.lightning_module.state_dict(), "resnet.pth")


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

`pytorch_lightning.metrics.Accuracy` has been deprecated - https://pytorch-lightning.readthedocs.io/en/stable/extensions/metrics.html .

The library has been moved to torchmetrics - https://torchmetrics.readthedocs.io/en/latest/?_ga=2.262900558.314526192.1636520294-1381146283.1614160028


## How is this patch tested?

Existing UTs

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [x] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
