### PR TITLE
Ptl 1.7.x fixes

### DIFF
--- a/examples/E2EBert/MLproject
+++ b/examples/E2EBert/MLproject
@@ -6,7 +6,7 @@ entry_points:
   main:
     parameters:
       max_epochs: {type: int, default: 5}
-      gpus: {type: int, default: 0}
+      devices: {type: int, default: None}
       num_samples: {type: int, default: 1000}
       vocab_file: {type: str, default: 'https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-vocab.txt'}
       strategy: {type str, default: None}
@@ -14,7 +14,7 @@ entry_points:
     command: |
           python news_classifier.py \
             --max_epochs {max_epochs} \
-            --gpus {gpus} \
+            --devices {devices} \
             --num_samples {num_samples} \
             --vocab_file {vocab_file} \
             --strategy={strategy}

--- a/examples/E2EBert/MLproject
+++ b/examples/E2EBert/MLproject
@@ -10,6 +10,7 @@ entry_points:
       num_samples: {type: int, default: 1000}
       vocab_file: {type: str, default: 'https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-vocab.txt'}
       strategy: {type str, default: None}
+      accelerator: {type str, default: None}
 
     command: |
           python news_classifier.py \
@@ -17,4 +18,5 @@ entry_points:
             --devices {devices} \
             --num_samples {num_samples} \
             --vocab_file {vocab_file} \
-            --strategy={strategy}
+            --strategy={strategy} \
+            --accelerator={accelerator}

--- a/examples/E2EBert/README.md
+++ b/examples/E2EBert/README.md
@@ -47,7 +47,7 @@ mlflow run . --no-conda
 To run it in gpu, use the following command
 
 ```
-mlflow run . -P gpus=2 -P accelerator="ddp"
+mlflow run . -P devices=2 -P strategy="ddp"
 ```
 
 Run the `news_classifier.py` script which will fine tune the model based on news dataset. 

--- a/examples/E2EBert/README.md
+++ b/examples/E2EBert/README.md
@@ -47,7 +47,7 @@ mlflow run . --no-conda
 To run it in gpu, use the following command
 
 ```
-mlflow run . -P devices=2 -P strategy="ddp"
+mlflow run . -P devices=2 -P strategy=ddp -P accelerator=gpu
 ```
 
 Run the `news_classifier.py` script which will fine tune the model based on news dataset. 

--- a/examples/E2EBert/conda.yaml
+++ b/examples/E2EBert/conda.yaml
@@ -12,6 +12,6 @@ dependencies:
   - transformers
   - torch>=1.9.0
   - torchtext>=0.10.0
-  - pytorch-lightning>=1.4.0
+  - pytorch-lightning>=1.7.6
   - torchvision>=0.10.0
   - torchdata

--- a/examples/E2EBert/news_classifier.py
+++ b/examples/E2EBert/news_classifier.py
@@ -445,9 +445,9 @@ if __name__ == "__main__":
     # autolog with only rank 0 gpu.
 
     # For CPU Training
-    if dict_args["gpus"] is None or int(dict_args["gpus"]) == 0:
+    if dict_args["devices"] is None or int(dict_args["devices"]) == 0:
         mlflow.pytorch.autolog()
-    elif int(dict_args["gpus"]) >= 1 and trainer.global_rank == 0:
+    elif int(dict_args["devices"]) >= 1 and trainer.global_rank == 0:
         # In case of multi gpu training, the training script is invoked multiple times,
         # The following condition is needed to avoid multiple copies of mlflow runs.
         # When one or more gpus are used for training, it is enough to save

--- a/examples/E2EBert/news_classifier.py
+++ b/examples/E2EBert/news_classifier.py
@@ -415,9 +415,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
-    if "strategy" in dict_args:
-        if dict_args["strategy"] == "None":
-            dict_args["strategy"] = None
+    for argument in ["strategy", "accelerator", "devices"]:
+        if dict_args[argument] == "None":
+            dict_args[argument] = None
 
     dm = BertDataModule(**dict_args)
     dm.prepare_data()

--- a/examples/E2EBert/requirements.txt
+++ b/examples/E2EBert/requirements.txt
@@ -1,12 +1,10 @@
 torchvision>=0.9.1
-torch>=1.9.0
-pytorch_lightning>=1.3.5
+torch>=1.12.0
+pytorch_lightning>=1.7.6
 mlflow
-gorilla
 torchserve
 torch-model-archiver
 numpy
 transformers
 sklearn
-tqdm
-torchtext>=0.10.0
+torchtext>=0.13.0

--- a/examples/IrisClassification/MLproject
+++ b/examples/IrisClassification/MLproject
@@ -6,11 +6,11 @@ entry_points:
   main:
     parameters:
       max_epochs: {type: int, default: 100}
-      gpus: {type: int, default: 0}
-      accelerator: {type str, default: "None"}
+      devices: {type: int, default: None}
+      strategy: {type str, default: "None"}
 
     command: |
           python iris_classification.py \
             --max_epochs {max_epochs} \
-            --gpus {gpus} \
-            --accelerator {accelerator}
+            --devices {devices} \
+            --strategy {strategy}

--- a/examples/IrisClassification/MLproject
+++ b/examples/IrisClassification/MLproject
@@ -8,9 +8,11 @@ entry_points:
       max_epochs: {type: int, default: 100}
       devices: {type: int, default: None}
       strategy: {type str, default: "None"}
+      accelerator: {type str, default: "None"}
 
     command: |
           python iris_classification.py \
             --max_epochs {max_epochs} \
             --devices {devices} \
-            --strategy {strategy}
+            --strategy {strategy} \
+            --accelerator {accelerator}

--- a/examples/IrisClassification/README.md
+++ b/examples/IrisClassification/README.md
@@ -33,7 +33,7 @@ mlflow run . --no-conda
 To run it in gpu, use the following command
 
 ```
-mlflow run . -P devices=2 -P strategy="ddp"
+mlflow run . -P devices=2 -P strategy="ddp -P accelerator=gpu"
 ```
 
 At the end of the training process, the model and its signature is saved in `model` directory.

--- a/examples/IrisClassification/README.md
+++ b/examples/IrisClassification/README.md
@@ -33,7 +33,7 @@ mlflow run . --no-conda
 To run it in gpu, use the following command
 
 ```
-mlflow run . -P gpus=2 -P accelerator="ddp"
+mlflow run . -P devices=2 -P strategy="ddp"
 ```
 
 At the end of the training process, the model and its signature is saved in `model` directory.

--- a/examples/IrisClassification/conda.yaml
+++ b/examples/IrisClassification/conda.yaml
@@ -7,8 +7,7 @@ dependencies:
 - pip
 - pip:
   - sklearn
-  - pytorch-lightning
+  - pytorch-lightning>=1.7.6
   - torch
   - torchvision
   - mlflow
-

--- a/examples/IrisClassification/iris_classification.py
+++ b/examples/IrisClassification/iris_classification.py
@@ -183,29 +183,26 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Iris Classification model")
 
     parser.add_argument(
-        "--max_epochs", type=int, default=100, help="number of epochs to run (default: 100)"
-    )
-    parser.add_argument(
-        "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
-    )
-    parser.add_argument(
         "--save-model",
         type=bool,
         default=True,
         help="For Saving the current Model",
     )
-    parser.add_argument(
-        "--accelerator",
-        type=lambda x: None if x == "None" else x,
-        default=None,
-        help="Accelerator - (default: None)",
-    )
 
+    parser = pl.Trainer.add_argparse_args(parent_parser=parser)
     parser = IrisClassification.add_model_specific_args(parent_parser=parser)
     parser = IrisDataModule.add_model_specific_args(parent_parser=parser)
 
     args = parser.parse_args()
     dict_args = vars(args)
+
+    if "strategy" in dict_args:
+        if dict_args["strategy"] == "None":
+            dict_args["strategy"] = None
+
+    if "devices" in dict_args:
+        if dict_args["devices"] == "None":
+            dict_args["devices"] = None
 
     dm = IrisDataModule(**dict_args)
     dm.prepare_data()

--- a/examples/IrisClassification/iris_classification.py
+++ b/examples/IrisClassification/iris_classification.py
@@ -196,13 +196,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
-    if "strategy" in dict_args:
-        if dict_args["strategy"] == "None":
-            dict_args["strategy"] = None
-
-    if "devices" in dict_args:
-        if dict_args["devices"] == "None":
-            dict_args["devices"] = None
+    for argument in ["strategy", "accelerator", "devices"]:
+        if dict_args[argument] == "None":
+            dict_args[argument] = None
 
     dm = IrisDataModule(**dict_args)
     dm.prepare_data()

--- a/examples/IrisClassification/iris_classification.py
+++ b/examples/IrisClassification/iris_classification.py
@@ -209,14 +209,15 @@ if __name__ == "__main__":
     trainer.fit(model, dm)
     trainer.test(datamodule=dm)
 
-    input_schema = Schema(
-        [
-            ColSpec("double", "sepal length (cm)"),
-            ColSpec("double", "sepal width (cm)"),
-            ColSpec("double", "petal length (cm)"),
-            ColSpec("double", "petal width (cm)"),
-        ]
-    )
-    output_schema = Schema([ColSpec("long")])
-    signature = ModelSignature(inputs=input_schema, outputs=output_schema)
-    mlflow.pytorch.save_model(trainer.lightning_module, "model", signature=signature)
+    if trainer.global_rank == 0:
+        input_schema = Schema(
+            [
+                ColSpec("double", "sepal length (cm)"),
+                ColSpec("double", "sepal width (cm)"),
+                ColSpec("double", "petal length (cm)"),
+                ColSpec("double", "petal width (cm)"),
+            ]
+        )
+        output_schema = Schema([ColSpec("long")])
+        signature = ModelSignature(inputs=input_schema, outputs=output_schema)
+        mlflow.pytorch.save_model(trainer.lightning_module, "model", signature=signature)

--- a/examples/IrisClassificationTorchScript/MLproject
+++ b/examples/IrisClassificationTorchScript/MLproject
@@ -6,11 +6,11 @@ entry_points:
   main:
     parameters:
       max_epochs: {type: int, default: 100}
-      gpus: {type: int, default: 0}
-      accelerator: {type str, default: "None"}
+      devices: {type: int, default: None}
+      strategy: {type str, default: "None"}
 
     command: |
           python iris_classification.py \
             --max_epochs {max_epochs} \
-            --gpus {gpus} \
-            --accelerator {accelerator}
+            --devices {devices} \
+            --strategy {strategy}

--- a/examples/IrisClassificationTorchScript/MLproject
+++ b/examples/IrisClassificationTorchScript/MLproject
@@ -8,9 +8,11 @@ entry_points:
       max_epochs: {type: int, default: 100}
       devices: {type: int, default: None}
       strategy: {type str, default: "None"}
+      accelerator: {type str, default: "None"}
 
     command: |
           python iris_classification.py \
             --max_epochs {max_epochs} \
             --devices {devices} \
-            --strategy {strategy}
+            --strategy {strategy} \
+            --accelerator {accelerator}

--- a/examples/IrisClassificationTorchScript/conda.yaml
+++ b/examples/IrisClassificationTorchScript/conda.yaml
@@ -11,5 +11,5 @@ dependencies:
       - mlflow
       - scikit-learn
       - torchvision
-      - pytorch-lightning>=1.3.5
+      - pytorch-lightning>=1.7.6
 

--- a/examples/IrisClassificationTorchScript/conda.yaml
+++ b/examples/IrisClassificationTorchScript/conda.yaml
@@ -4,12 +4,12 @@ channels:
   - pytorch
 dependencies:
   - python=3.8.2
-  - pytorch>=1.9.0
-  - torchvision
   - pip
   - pip:
       - mlflow
       - scikit-learn
+      - torchvision
+      - torch>=1.9.0
       - torchvision
       - pytorch-lightning>=1.7.6
 

--- a/examples/IrisClassificationTorchScript/iris_classification.py
+++ b/examples/IrisClassificationTorchScript/iris_classification.py
@@ -83,21 +83,7 @@ class IrisClassification(pl.LightningModule):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-
-    parser.add_argument(
-        "--max_epochs",
-        default=20,
-        help="Describes the number of times a neural network has to be trained",
-    )
-    parser.add_argument(
-        "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
-    )
-    parser.add_argument(
-        "--accelerator",
-        type=lambda x: None if x == "None" else x,
-        default=None,
-        help="Accelerator - (default: None)",
-    )
+    parser = pl.Trainer.add_argparse_args(parent_parser=parser)
     args = parser.parse_args()
     mlflow.pytorch.autolog()
     trainer = pl.Trainer(max_epochs=int(args.max_epochs))

--- a/examples/IrisClassificationTorchScript/iris_classification.py
+++ b/examples/IrisClassificationTorchScript/iris_classification.py
@@ -85,15 +85,23 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser = pl.Trainer.add_argparse_args(parent_parser=parser)
     args = parser.parse_args()
+    dict_args = vars(args)
+
+    for argument in ["strategy", "accelerator", "devices"]:
+        if dict_args[argument] == "None":
+            dict_args[argument] = None
+
     mlflow.pytorch.autolog()
-    trainer = pl.Trainer(max_epochs=int(args.max_epochs))
     model = IrisClassification()
     import iris_datamodule
 
     dm = iris_datamodule.IRISDataModule()
+    dm.prepare_data()
     dm.setup("fit")
+
+    trainer = pl.Trainer.from_argparse_args(args)
     trainer.fit(model, dm)
-    testloader = dm.setup("test")
+    trainer.test(datamodule=dm)
     trainer.test(datamodule=dm)
     if trainer.global_rank == 0:
         scripted_model = torch.jit.script(model)

--- a/examples/MNIST/MLproject
+++ b/examples/MNIST/MLproject
@@ -14,5 +14,5 @@ entry_points:
           python mnist_model.py \
             --max_epochs {max_epochs} \
             --gpus {gpus} \
-            --strategy {accelerator} \
+            --strategy {strategy} \
             --registration_name {registration_name} \

--- a/examples/MNIST/MLproject
+++ b/examples/MNIST/MLproject
@@ -1,4 +1,4 @@
-name: mnist-example1
+name: mnist-example
 
 conda_env: conda.yaml
 
@@ -6,13 +6,15 @@ entry_points:
   main:
     parameters:
       max_epochs: {type: int, default: 5}
-      gpus: {type: int, default: 0}
+      devices: {type: int, default: None}
       strategy: {type: str, default: "None"}
+      accelerator: {type: str, default: "cpu"}
       registration_name: {type: str, default: "mnist_classifier"}
 
     command: |
           python mnist_model.py \
             --max_epochs {max_epochs} \
-            --gpus {gpus} \
+            --devices {devices} \
             --strategy {strategy} \
-            --registration_name {registration_name} \
+            --accelerator {accelerator} \
+            --registration_name {registration_name}

--- a/examples/MNIST/MLproject
+++ b/examples/MNIST/MLproject
@@ -7,12 +7,12 @@ entry_points:
     parameters:
       max_epochs: {type: int, default: 5}
       gpus: {type: int, default: 0}
-      accelerator: {type: str, default: "None"}
+      strategy: {type: str, default: "None"}
       registration_name: {type: str, default: "mnist_classifier"}
 
     command: |
           python mnist_model.py \
             --max_epochs {max_epochs} \
             --gpus {gpus} \
-            --accelerator {accelerator} \
+            --strategy {accelerator} \
             --registration_name {registration_name} \

--- a/examples/MNIST/MLproject
+++ b/examples/MNIST/MLproject
@@ -6,9 +6,9 @@ entry_points:
   main:
     parameters:
       max_epochs: {type: int, default: 5}
-      devices: {type: int, default: None}
+      devices: {type: int, default: "None"}
       strategy: {type: str, default: "None"}
-      accelerator: {type: str, default: "cpu"}
+      accelerator: {type: str, default: "None"}
       registration_name: {type: str, default: "mnist_classifier"}
 
     command: |

--- a/examples/MNIST/README.md
+++ b/examples/MNIST/README.md
@@ -15,7 +15,7 @@ Python scripts `create_deployment.py` and `predict.py` have been used for this p
 Run the following command to train the MNIST model
 
 CPU: `mlflow run . -P max_epochs=5`
-GPU: `mlflow run . -P max_epochs=5 -P devices=2 -P strategy=ddp`
+GPU: `mlflow run . -P max_epochs=5 -P devices=2 -P strategy=ddp -P accelerator=gpu`
 
 At the end of the training, MNIST model will be saved as state dict in the current working directory
 

--- a/examples/MNIST/README.md
+++ b/examples/MNIST/README.md
@@ -15,7 +15,7 @@ Python scripts `create_deployment.py` and `predict.py` have been used for this p
 Run the following command to train the MNIST model
 
 CPU: `mlflow run . -P max_epochs=5`
-GPU: `mlflow run . -P max_epochs=5 -P gpus=2 -P accelerator=ddp`
+GPU: `mlflow run . -P max_epochs=5 -P devices=2 -P strategy=ddp`
 
 At the end of the training, MNIST model will be saved as state dict in the current working directory
 

--- a/examples/MNIST/conda.yaml
+++ b/examples/MNIST/conda.yaml
@@ -6,7 +6,7 @@ dependencies:
 - python=3.8.2
 - pip
 - pip:
-  - torch>=1.10.0
+  - torch>=1.9.0
   - torchvision
   - matplotlib
   - pytorch-lightning>=1.7.6

--- a/examples/MNIST/conda.yaml
+++ b/examples/MNIST/conda.yaml
@@ -4,10 +4,10 @@ channels:
 - pytorch
 dependencies:
 - python=3.8.2
-- pytorch>=1.9.0
-- torchvision
 - pip
 - pip:
+  - torch>=1.10.0
+  - torchvision
   - matplotlib
   - pytorch-lightning>=1.7.6
   - mlflow>=1.14.0

--- a/examples/MNIST/conda.yaml
+++ b/examples/MNIST/conda.yaml
@@ -9,6 +9,6 @@ dependencies:
 - pip
 - pip:
   - matplotlib
-  - pytorch-lightning>=1.3.5
+  - pytorch-lightning>=1.7.6
   - mlflow>=1.14.0
   - captum

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -208,7 +208,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         loss = self.cross_entropy_loss(logits, y)
         _, y_hat = torch.max(logits, dim=1)
         self.val_acc(y_hat, y)
-        self.log("val_acc", self.val_acc.compute())
+        self.log("val_acc", self.val_acc.compute(), sync_dist=True)
         self.log("val_loss", loss, sync_dist=True)
 
     def test_step(self, test_batch, batch_idx):

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -275,9 +275,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
-    if "strategy" in dict_args:
-        if dict_args["strategy"] == "None":
-            dict_args["strategy"] = None
+    for argument in ["strategy", "accelerator", "devices"]:
+        if dict_args[argument] == "None":
+            dict_args[argument] = None
 
     mlflow.pytorch.autolog()
 

--- a/examples/MNIST/mnist_model.py
+++ b/examples/MNIST/mnist_model.py
@@ -13,11 +13,6 @@ from argparse import ArgumentParser
 import mlflow.pytorch
 import pytorch_lightning as pl
 import torch
-
-# from pytorch_lightning.overrides.data_parallel import (
-#     LightningDistributedDataParallel,
-#     LightningDataParallel,
-# )
 from torch.nn.parallel import (
     DistributedDataParallel,
     DataParallel,
@@ -280,9 +275,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
-    if "accelerator" in dict_args:
-        if dict_args["accelerator"] == "None":
-            dict_args["accelerator"] = None
+    if "strategy" in dict_args:
+        if dict_args["strategy"] == "None":
+            dict_args["strategy"] = None
 
     mlflow.pytorch.autolog()
 

--- a/examples/cifar10/MLproject
+++ b/examples/cifar10/MLproject
@@ -8,6 +8,7 @@ entry_points:
       max_epochs: {type: int, default: 1}
       devices: {type: int, default: None}
       strategy: {type: str, default: "None"}
+      accelerator: {type: str, default: "None"}
       num_samples_train: {type: int, default: 39}
       num_samples_val: {type: int, default: 9}
       num_samples_test: {type: int, default: 9}
@@ -19,4 +20,5 @@ entry_points:
             --num_samples_train {num_samples_train} \
             --num_samples_val {num_samples_val} \
             --num_samples_test {num_samples_test} \
-            --strategy {strategy}
+            --strategy {strategy} \
+            --accelerator {strategy}

--- a/examples/cifar10/MLproject
+++ b/examples/cifar10/MLproject
@@ -21,4 +21,4 @@ entry_points:
             --num_samples_val {num_samples_val} \
             --num_samples_test {num_samples_test} \
             --strategy {strategy} \
-            --accelerator {strategy}
+            --accelerator {accelerator}

--- a/examples/cifar10/MLproject
+++ b/examples/cifar10/MLproject
@@ -6,8 +6,8 @@ entry_points:
   main:
     parameters:
       max_epochs: {type: int, default: 1}
-      gpus: {type: int, default: 0}
-      accelerator: {type: str, default: "None"}
+      devices: {type: int, default: None}
+      strategy: {type: str, default: "None"}
       num_samples_train: {type: int, default: 39}
       num_samples_val: {type: int, default: 9}
       num_samples_test: {type: int, default: 9}
@@ -15,8 +15,8 @@ entry_points:
     command: |
           python cifar10_train.py \
             --max_epochs {max_epochs} \
-            --gpus {gpus} \
+            --devices {devices} \
             --num_samples_train {num_samples_train} \
             --num_samples_val {num_samples_val} \
             --num_samples_test {num_samples_test} \
-            --accelerator {accelerator}
+            --strategy {strategy}

--- a/examples/cifar10/README.md
+++ b/examples/cifar10/README.md
@@ -15,7 +15,7 @@ Python scripts `create_deployment.py` and `predict.py` have been used for this p
 Run the following command to train the cifar10 model
 
 CPU: `mlflow run . -P max_epochs=5`
-GPU: `mlflow run . -P max_epochs=5 -P gpus=2 -P accelerator=ddp`
+GPU: `mlflow run . -P max_epochs=5 -P devices=2 -P strategy=ddp -P accelerator=gpu`
 
 At the end of the training, Cifar10 model will be saved as state dict (resnet.pth) in the current working directory
 

--- a/examples/cifar10/cifar10_datamodule.py
+++ b/examples/cifar10/cifar10_datamodule.py
@@ -142,29 +142,41 @@ class CIFAR10DataModule(pl.LightningDataModule):  # pylint: disable=too-many-ins
         valid_url = "{}/{}-{}".format(val_base_url, "val", "{0.." + str(val_count) + "}.tar")
         test_url = "{}/{}-{}".format(test_base_url, "test", "{0.." + str(test_count) + "}.tar")
 
-        self.train_dataset = (wds.WebDataset(
-            train_url,
-            handler=wds.warn_and_continue,
-            nodesplitter=wds.shardlists.split_by_node).shuffle(100).decode("pil").rename(
-                image="ppm;jpg;jpeg;png",
-                info="cls").map_dict(image=self.train_transform).to_tuple(
-                    "image", "info").batched(40))
+        self.train_dataset = (
+            wds.WebDataset(
+                train_url, handler=wds.warn_and_continue, nodesplitter=wds.shardlists.split_by_node
+            )
+            .shuffle(100)
+            .decode("pil")
+            .rename(image="ppm;jpg;jpeg;png", info="cls")
+            .map_dict(image=self.train_transform)
+            .to_tuple("image", "info")
+            .batched(40)
+        )
 
-        self.valid_dataset = (wds.WebDataset(
-            valid_url,
-            handler=wds.warn_and_continue,
-            nodesplitter=wds.shardlists.split_by_node).shuffle(100).decode("pil").rename(
-                image="ppm",
-                info="cls").map_dict(image=self.valid_transform).to_tuple(
-                    "image", "info").batched(20))
+        self.valid_dataset = (
+            wds.WebDataset(
+                valid_url, handler=wds.warn_and_continue, nodesplitter=wds.shardlists.split_by_node
+            )
+            .shuffle(100)
+            .decode("pil")
+            .rename(image="ppm", info="cls")
+            .map_dict(image=self.valid_transform)
+            .to_tuple("image", "info")
+            .batched(20)
+        )
 
-        self.test_dataset = (wds.WebDataset(
-            test_url,
-            handler=wds.warn_and_continue,
-            nodesplitter=wds.shardlists.split_by_node).shuffle(100).decode("pil").rename(
-                image="ppm",
-                info="cls").map_dict(image=self.valid_transform).to_tuple(
-                    "image", "info").batched(20))
+        self.test_dataset = (
+            wds.WebDataset(
+                test_url, handler=wds.warn_and_continue, nodesplitter=wds.shardlists.split_by_node
+            )
+            .shuffle(100)
+            .decode("pil")
+            .rename(image="ppm", info="cls")
+            .map_dict(image=self.valid_transform)
+            .to_tuple("image", "info")
+            .batched(20)
+        )
 
     def create_data_loader(self, dataset, batch_size, num_workers):  # pylint: disable=no-self-use
         """Creates data loader."""

--- a/examples/cifar10/cifar10_datamodule.py
+++ b/examples/cifar10/cifar10_datamodule.py
@@ -142,35 +142,29 @@ class CIFAR10DataModule(pl.LightningDataModule):  # pylint: disable=too-many-ins
         valid_url = "{}/{}-{}".format(val_base_url, "val", "{0.." + str(val_count) + "}.tar")
         test_url = "{}/{}-{}".format(test_base_url, "test", "{0.." + str(test_count) + "}.tar")
 
-        self.train_dataset = (
-            wds.WebDataset(train_url, handler=wds.warn_and_continue)
-            .shuffle(100)
-            .decode("pil")
-            .rename(image="ppm;jpg;jpeg;png", info="cls")
-            .map_dict(image=self.train_transform)
-            .to_tuple("image", "info")
-            .batched(40)
-        )
+        self.train_dataset = (wds.WebDataset(
+            train_url,
+            handler=wds.warn_and_continue,
+            nodesplitter=wds.shardlists.split_by_node).shuffle(100).decode("pil").rename(
+                image="ppm;jpg;jpeg;png",
+                info="cls").map_dict(image=self.train_transform).to_tuple(
+                    "image", "info").batched(40))
 
-        self.valid_dataset = (
-            wds.WebDataset(valid_url, handler=wds.warn_and_continue)
-            .shuffle(100)
-            .decode("pil")
-            .rename(image="ppm", info="cls")
-            .map_dict(image=self.valid_transform)
-            .to_tuple("image", "info")
-            .batched(20)
-        )
+        self.valid_dataset = (wds.WebDataset(
+            valid_url,
+            handler=wds.warn_and_continue,
+            nodesplitter=wds.shardlists.split_by_node).shuffle(100).decode("pil").rename(
+                image="ppm",
+                info="cls").map_dict(image=self.valid_transform).to_tuple(
+                    "image", "info").batched(20))
 
-        self.test_dataset = (
-            wds.WebDataset(test_url, handler=wds.warn_and_continue)
-            .shuffle(100)
-            .decode("pil")
-            .rename(image="ppm", info="cls")
-            .map_dict(image=self.valid_transform)
-            .to_tuple("image", "info")
-            .batched(20)
-        )
+        self.test_dataset = (wds.WebDataset(
+            test_url,
+            handler=wds.warn_and_continue,
+            nodesplitter=wds.shardlists.split_by_node).shuffle(100).decode("pil").rename(
+                image="ppm",
+                info="cls").map_dict(image=self.valid_transform).to_tuple(
+                    "image", "info").batched(20))
 
     def create_data_loader(self, dataset, batch_size, num_workers):  # pylint: disable=no-self-use
         """Creates data loader."""

--- a/examples/cifar10/cifar10_train.py
+++ b/examples/cifar10/cifar10_train.py
@@ -201,9 +201,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
-    if "strategy" in dict_args:
-        if dict_args["strategy"] == "None":
-            dict_args["strategy"] = None
+    for argument in ["strategy", "accelerator", "devices"]:
+        if dict_args[argument] == "None":
+            dict_args[argument] = None
 
     mlflow.pytorch.autolog()
 

--- a/examples/cifar10/cifar10_train.py
+++ b/examples/cifar10/cifar10_train.py
@@ -178,11 +178,6 @@ class CIFAR10Classifier(
         """
         self.show_activations(self.reference_image)
 
-        # Logging graph
-        if self.current_epoch == 0:
-            sample_img = torch.rand((1, 3, 64, 64))
-            self.logger.experiment.add_graph(CIFAR10Classifier(), sample_img)
-
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="PyTorch Cifar10 Example")
@@ -210,7 +205,6 @@ if __name__ == "__main__":
     model = CIFAR10Classifier(**dict_args)
 
     dm = CIFAR10DataModule(**dict_args)
-    dm.prepare_data()
     dm.setup(stage="fit")
 
     trainer = pl.Trainer.from_argparse_args(args)

--- a/examples/cifar10/cifar10_train.py
+++ b/examples/cifar10/cifar10_train.py
@@ -79,11 +79,7 @@ class CIFAR10Classifier(
         output = self.forward(x_var)
         _, y_hat = torch.max(output, dim=1)
         loss = F.cross_entropy(output, y_var)
-        accelerator = self.args.get("accelerator", None)
-        if accelerator is not None:
-            self.log("test_loss", loss, sync_dist=True)
-        else:
-            self.log("test_loss", loss)
+        self.log("test_loss", loss, sync_dist=True)
         self.test_acc(y_hat, y_var)
         self.preds += y_hat.tolist()
         self.target += y_var.tolist()
@@ -104,11 +100,7 @@ class CIFAR10Classifier(
         output = self.forward(x_var)
         _, y_hat = torch.max(output, dim=1)
         loss = F.cross_entropy(output, y_var)
-        accelerator = self.args.get("accelerator", None)
-        if accelerator is not None:
-            self.log("val_loss", loss, sync_dist=True)
-        else:
-            self.log("val_loss", loss)
+        self.log("val_loss", loss, sync_dist=True)
         self.val_acc(y_hat, y_var)
         self.log("val_acc", self.val_acc.compute())
         return {"val_step_loss": loss, "val_loss": loss}
@@ -209,9 +201,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
-    if "accelerator" in dict_args:
-        if dict_args["accelerator"] == "None":
-            dict_args["accelerator"] = None
+    if "strategy" in dict_args:
+        if dict_args["strategy"] == "None":
+            dict_args["strategy"] = None
 
     mlflow.pytorch.autolog()
 

--- a/examples/cifar10/conda.yaml
+++ b/examples/cifar10/conda.yaml
@@ -4,14 +4,13 @@ channels:
 - pytorch
 dependencies:
 - python=3.8.2
-- cudatoolkit=10.2
-- pytorch>=1.9.0
-- torchvision
 - pip
 - pip:
   - matplotlib
+  - torch>=1.9.0
   - pytorch-lightning>=1.7.6
   - mlflow>=1.14.0
   - captum
   - webdataset
   - sklearn
+  - torchvision

--- a/examples/cifar10/conda.yaml
+++ b/examples/cifar10/conda.yaml
@@ -10,7 +10,7 @@ dependencies:
 - pip
 - pip:
   - matplotlib
-  - pytorch-lightning==1.4.0
+  - pytorch-lightning>=1.7.6
   - mlflow>=1.14.0
   - captum
   - webdataset


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updating all the examples to run with pytorch lightning 1.7

## How is this patch tested?

All the unit tests should pass

MNIST
=====
[mnist_predict.txt](https://github.com/mlflow/mlflow-torchserve/files/9623313/mnist_predict.txt)
[mnist_register.txt](https://github.com/mlflow/mlflow-torchserve/files/9623314/mnist_register.txt)
[mnist_training_cpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9623315/mnist_training_cpu.txt)
[mnist_training_gpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9623316/mnist_training_gpu.txt)

Bert
=====

[bert_explain.txt](https://github.com/mlflow/mlflow-torchserve/files/9623891/bert_explain.txt)
[bert_predict.txt](https://github.com/mlflow/mlflow-torchserve/files/9623893/bert_predict.txt)
[bert_register.txt](https://github.com/mlflow/mlflow-torchserve/files/9623894/bert_register.txt)
[bert_training_cpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9623895/bert_training_cpu.txt)
[bert_training_gpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9623896/bert_training_gpu.txt)
![captum](https://user-images.githubusercontent.com/63862647/191698618-e26e13ac-c546-4eee-9e36-f39b1405cb91.png)

Iris Classification
=============
[iris_model_signature.txt](https://github.com/mlflow/mlflow-torchserve/files/9624125/iris_model_signature.txt)
[iris_predict.txt](https://github.com/mlflow/mlflow-torchserve/files/9624127/iris_predict.txt)
[iris_register.txt](https://github.com/mlflow/mlflow-torchserve/files/9624128/iris_register.txt)
[iris_training_cpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9624129/iris_training_cpu.txt)
[iris_training_gpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9624131/iris_training_gpu.txt)

Iris Classification - torchscripted
========================
[iris_torchscripted_predict.txt](https://github.com/mlflow/mlflow-torchserve/files/9624488/iris_torchscripted_predict.txt)
[iris_torchscripted_register.txt](https://github.com/mlflow/mlflow-torchserve/files/9624489/iris_torchscripted_register.txt)
[iris_torchscripted_training_cpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9624490/iris_torchscripted_training_cpu.txt)
[iris_torchscripted_training_gpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9624491/iris_torchscripted_training_gpu.txt)


cifar
====
[cifar_predict.txt](https://github.com/mlflow/mlflow-torchserve/files/9625424/cifar_predict.txt)
[cifar_register.txt](https://github.com/mlflow/mlflow-torchserve/files/9625425/cifar_register.txt)
[cifar_training_cpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9625426/cifar_training_cpu.txt)
[cifar_training_gpu.txt](https://github.com/mlflow/mlflow-torchserve/files/9625427/cifar_training_gpu.txt)


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [x] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
